### PR TITLE
Adicionando docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.1'
+
+services:
+  mysql:
+    image: mysql
+    container_name: miniasaas-mysql
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: miniasaas
+      MYSQL_PASSWORD: root
+    ports:
+      - "3306:3306"

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -97,19 +97,20 @@ hibernate:
         queries: false
         use_second_level_cache: false
         use_query_cache: false
+    hibernateDirtyChecking: true
 dataSource:
     pooled: true
     jmxExport: true
     driverClassName: com.mysql.cj.jdbc.Driver
     dialect: org.hibernate.dialect.MySQL8Dialect
-    username: yourUsernameHere
-    password: yourPasswordHere
+    username: root
+    password: root
 
 environments:
     development:
         dataSource:
             dbCreate: update
-            url: jdbc:mysql://127.0.0.1:3306/mini_asaas
+            url: jdbc:mysql://127.0.0.1:3306/miniasaas
     test:
         dataSource:
             dbCreate: update


### PR DESCRIPTION
Através desse pr, o docker é adicionado ao projeto com o intuito de facilitar a criação, configuração e utilização de banco de dados da aplicação.

Formas de uso:
`docker compose up -d` - Na raiz do projeto para iniciar o banco de dados.
`docker compose stop` - Na raiz do projeto para parar o banco de dados.