### PR TITLE
Validação de Estado

### DIFF
--- a/src/main/groovy/com/miniasaaslw/utils/StateUtils.groovy
+++ b/src/main/groovy/com/miniasaaslw/utils/StateUtils.groovy
@@ -2,10 +2,18 @@ package com.miniasaaslw.utils
 
 class StateUtils {
 
+    private static final List<String> statesFromBrasil = [
+        "AC", "AL", "AP", "AM", "BA", "CE", "DF", "ES", "GO", "MA", "MT",
+        "MS", "MG", "PA", "PB", "PR", "PE", "PI", "RJ", "RN", "RS", "RO",
+        "RR", "SC", "SP", "SE", "TO"
+    ]
+
     public static boolean isStateValid(String state) {
         if (state == null) return false
 
-        if (!state.matches('^[a-zA-Z]{2}$')) return false
+        if (state.length() != 2) return false
+
+        if (!statesFromBrasil.contains(state.toUpperCase())) return false
 
         return true
     }

--- a/src/main/groovy/com/miniasaaslw/utils/StateUtils.groovy
+++ b/src/main/groovy/com/miniasaaslw/utils/StateUtils.groovy
@@ -3,6 +3,10 @@ package com.miniasaaslw.utils
 class StateUtils {
 
     public static boolean isStateValid(String state) {
-        return state != null && state.matches('^[a-zA-Z]{2}$')
+        if (state == null) return false
+
+        if (!state.matches('^[a-zA-Z]{2}$')) return false
+
+        return true
     }
 }

--- a/src/main/groovy/com/miniasaaslw/utils/StateUtils.groovy
+++ b/src/main/groovy/com/miniasaaslw/utils/StateUtils.groovy
@@ -1,0 +1,8 @@
+package com.miniasaaslw.utils
+
+class StateUtils {
+
+    public static boolean isStateValid(String state) {
+        return state != null && state.matches('^[a-zA-Z]{2}$')
+    }
+}


### PR DESCRIPTION
Com esse PR é adicionado a implementação do StateUtils para validar um estado seguindo a regra:

O estado precisa possuir duas letras alfabéticas, exemplo: PE, MG, SP.