### PR TITLE
Bloqueando criação de customers com emails duplicados

### DIFF
--- a/grails-app/services/com/miniasaaslw/service/customer/CustomerService.groovy
+++ b/grails-app/services/com/miniasaaslw/service/customer/CustomerService.groovy
@@ -75,10 +75,6 @@ class CustomerService {
             customer.errors.reject("cpfCnpj", null, "CPF/CNPJ é obrigatório!")
         }
 
-        if (CustomerRepository.exists([cpfCnpj: customerAdapter.cpfCnpj])) {
-            customer.errors.reject("cpfCnpj", null, "CPF/CNPJ já cadastrado!")
-        }
-
         if (!customerAdapter.personType) {
             customer.errors.reject("personType", null, "Tipo de pessoa é obrigatório!")
         }
@@ -133,6 +129,14 @@ class CustomerService {
 
         if (customerAdapter.cep != null && !CepUtils.validateCep(customerAdapter.cep)) {
             customer.errors.reject("cep", null, "CEP inválido!")
+        }
+
+        if (CustomerRepository.exists([cpfCnpj: customerAdapter.cpfCnpj])) {
+            customer.errors.reject("cpfCnpj", null, "CPF/CNPJ já cadastrado!")
+        }
+
+        if (CustomerRepository.exists([email: customerAdapter.email])) {
+            customer.errors.reject("email", null, "Email já cadastrado!")
         }
 
         return customer

--- a/src/main/groovy/com/miniasaaslw/repository/customer/CustomerRepository.groovy
+++ b/src/main/groovy/com/miniasaaslw/repository/customer/CustomerRepository.groovy
@@ -10,8 +10,12 @@ class CustomerRepository implements BaseEntityRepository {
         DetachedCriteria<Customer> query = Customer.where(defaultQuery(search))
 
         query = query.where {
-            if (search.cpfCnpj) {
+            if (search.containsKey("cpfCnpj")) {
                 eq("cpfCnpj", search.cpfCnpj)
+            }
+
+            if (search.containsKey("email")) {
+                eq("email", search.email)
             }
         }
 


### PR DESCRIPTION
Nesse PR é feito uma checagem no banco de dados na hora de criação de um customer para saber se já possui um email igual.

Além disso, foi feito uma pequena alteração na condicional de verificação do cpfCnpj para padronização sem afetar seu uso.