### PR TITLE
Adicionando filtro para exibir pagadores deletados

### DIFF
--- a/grails-app/assets/javascripts/PayerListController.js
+++ b/grails-app/assets/javascripts/PayerListController.js
@@ -34,11 +34,9 @@ function PayerListController(reference) {
             inputReference.readonly = true;
 
             var filterData = filterReference.getFilterData();
+            filterData.name = inputReference.value;
 
-            tableReference.params = {
-                name: inputReference.value,
-                filters: filterData.list
-            }
+            tableReference.params = filterData
         });
 
         tableReference.addEventListener("atlas-table-after-search", function () {

--- a/grails-app/assets/javascripts/PayerListController.js
+++ b/grails-app/assets/javascripts/PayerListController.js
@@ -2,7 +2,7 @@ function PayerListController(reference) {
 
     var tableReference = reference.querySelector(".js-payer-list-table");
     var inputReference = reference.querySelector(".js-payer-search-input");
-    var filterReference = reference.querySelector(".js-payer-filter-input")
+    var filterReference = reference.querySelector(".js-payer-filter-input");
     var deleteRow = null;
 
     function init() {
@@ -36,7 +36,7 @@ function PayerListController(reference) {
             var filterData = filterReference.getFilterData();
             filterData.name = inputReference.value;
 
-            tableReference.params = filterData
+            tableReference.params = filterData;
         });
 
         tableReference.addEventListener("atlas-table-after-search", function () {

--- a/grails-app/assets/javascripts/PayerListController.js
+++ b/grails-app/assets/javascripts/PayerListController.js
@@ -37,7 +37,7 @@ function PayerListController(reference) {
 
             tableReference.params = {
                 name: inputReference.value,
-                filter: filterData.list
+                filters: filterData.list
             }
         });
 

--- a/grails-app/assets/javascripts/PayerListController.js
+++ b/grails-app/assets/javascripts/PayerListController.js
@@ -2,12 +2,24 @@ function PayerListController(reference) {
 
     var tableReference = reference.querySelector(".js-payer-list-table");
     var inputReference = reference.querySelector(".js-payer-search-input");
+    var filterReference = reference.querySelector(".js-payer-filter-input")
     var deleteRow = null;
 
     function init() {
         bindInputReference();
         bindTableSearch();
         bindTableActions();
+        bindFilterReference();
+    }
+
+    function bindFilterReference() {
+        filterReference.addEventListener("atlas-apply-filter", function () {
+            tableReference.fetchRecords(true);
+        });
+
+        filterReference.addEventListener("atlas-clean-filter", function () {
+            tableReference.fetchRecords(true);
+        });
     }
 
     function bindInputReference() {
@@ -18,9 +30,14 @@ function PayerListController(reference) {
 
     function bindTableSearch() {
         tableReference.addEventListener("atlas-table-before-search", function () {
+            filterReference.enableButtons();
             inputReference.readonly = true;
+
+            var filterData = filterReference.getFilterData();
+
             tableReference.params = {
-                name: inputReference.value
+                name: inputReference.value,
+                filter: filterData.list
             }
         });
 

--- a/grails-app/controllers/com/miniasaaslw/controller/payer/PayerController.groovy
+++ b/grails-app/controllers/com/miniasaaslw/controller/payer/PayerController.groovy
@@ -19,7 +19,7 @@ class PayerController extends BaseController {
         List<Customer> customers = CustomerRepository.query([:]).list()
 
         if (errors) {
-            return [errors: errors, customers : customers]
+            return [errors: errors, customers: customers]
         }
 
         return [customers: customers]
@@ -89,9 +89,15 @@ class PayerController extends BaseController {
         return [payerList: payerService.list(getLimitPerPage(), getOffset(), [:])]
     }
 
-    def loadTableContent(){
+    def loadTableContent() {
         Map search = [:]
-        if(params.name) search."name[like]" = params.name
+        def filters = params.filter
+
+        if (filters) {
+            if (filters.contains("includeDeleted")) search.includeDeleted = true
+        }
+
+        if (params.name) search."name[like]" = params.name
 
         List<Payer> payerList = payerService.list(getLimitPerPage(), getOffset(), search)
         Integer totalRecords = payerList.totalCount

--- a/grails-app/controllers/com/miniasaaslw/controller/payer/PayerController.groovy
+++ b/grails-app/controllers/com/miniasaaslw/controller/payer/PayerController.groovy
@@ -91,12 +91,8 @@ class PayerController extends BaseController {
 
     def loadTableContent() {
         Map search = [:]
-        def filters = params.filters
 
-        if (filters) {
-            if (filters.contains("includeDeleted")) search.includeDeleted = true
-        }
-
+        if (params.includeDeleted) search.includeDeleted = Boolean.valueOf(params.includeDeleted)
         if (params.name) search."name[like]" = params.name
 
         List<Payer> payerList = payerService.list(getLimitPerPage(), getOffset(), search)

--- a/grails-app/controllers/com/miniasaaslw/controller/payer/PayerController.groovy
+++ b/grails-app/controllers/com/miniasaaslw/controller/payer/PayerController.groovy
@@ -91,7 +91,7 @@ class PayerController extends BaseController {
 
     def loadTableContent() {
         Map search = [:]
-        def filters = params.filter
+        def filters = params.filters
 
         if (filters) {
             if (filters.contains("includeDeleted")) search.includeDeleted = true

--- a/grails-app/views/payer/list.gsp
+++ b/grails-app/views/payer/list.gsp
@@ -11,14 +11,14 @@
             <atlas-search-input class="js-payer-search-input" placeholder="Pesquisar" icon="magnifier"
                                 slot="search"></atlas-search-input>
             <atlas-button description="Adicionar" icon="plus" slot="actions"></atlas-button>
+            <atlas-filter class="js-payer-filter-input" slot="filter">
+                <atlas-filter-form slot="simple-filter">
+                    <atlas-filter-group header="Listagem" name="includeDeleted" slot="col-1">
+                        <atlas-checkbox value="true">Exibir deletados</atlas-checkbox>
+                    </atlas-filter-group>
+                </atlas-filter-form>
+            </atlas-filter>
         </atlas-toolbar>
-        <atlas-filter class="js-payer-filter-input">
-            <atlas-filter-form slot="simple-filter">
-                <atlas-filter-group header="Listagem" name="list" slot="col-1">
-                    <atlas-checkbox value="includeDeleted">Exibir deletados</atlas-checkbox>
-                </atlas-filter-group>
-            </atlas-filter-form>
-        </atlas-filter>
 
         <g:render template="/payer/templates/table"/>
         <asset:javascript src="PayerListController.js"/>

--- a/grails-app/views/payer/list.gsp
+++ b/grails-app/views/payer/list.gsp
@@ -12,6 +12,13 @@
                                 slot="search"></atlas-search-input>
             <atlas-button description="Adicionar" icon="plus" slot="actions"></atlas-button>
         </atlas-toolbar>
+        <atlas-filter class="js-payer-filter-input">
+            <atlas-filter-form slot="simple-filter">
+                <atlas-filter-group header="Listagem" name="list" slot="col-1">
+                    <atlas-checkbox value="includeDeleted">Exibir deletados</atlas-checkbox>
+                </atlas-filter-group>
+            </atlas-filter-form>
+        </atlas-filter>
 
         <g:render template="/payer/templates/table"/>
         <asset:javascript src="PayerListController.js"/>

--- a/grails-app/views/payer/templates/_tableContent.gsp
+++ b/grails-app/views/payer/templates/_tableContent.gsp
@@ -20,13 +20,24 @@
                     theme="primary"
                     description="Editar pagador">
             </atlas-icon-button>
-            <atlas-icon-button
-                    data-action="delete"
-                    tooltip="Remover pagador"
-                    icon="trash"
-                    theme="danger"
-                    description="Remover pagador">
-            </atlas-icon-button>
+            <g:if test="${payer.deleted}">
+                <atlas-icon-button
+                        data-action=""
+                        tooltip="Restaurar pagador"
+                        icon="refresh"
+                        theme="warning"
+                        description="Restaurar pagador">
+                </atlas-icon-button>
+            </g:if>
+            <g:else>
+                <atlas-icon-button
+                        data-action="delete"
+                        tooltip="Remover pagador"
+                        icon="trash"
+                        theme="danger"
+                        description="Remover pagador">
+                </atlas-icon-button>
+            </g:else>
         </atlas-button-group>
     </atlas-table-row>
 </g:each>


### PR DESCRIPTION
### Impacto

Agora é possível visualizar pagadores que foram deletados, para futuramente ser possível restaurá-los

Foi adicionado um botão de "restaurar" que por enquanto ainda não é funcional, é só um indicativo de que aquele pagador em específico na listagem está deletado

### PR Predecessora
[81](https://github.com/L-W-payments/asaas-payment/pull/81)

### Link da tarefa

https://github.com/orgs/L-W-payments/projects/1?pane=issue&itemId=65886613

### Prints do desenvolvimento

Tela com o filtro:
![image](https://github.com/L-W-payments/asaas-payment/assets/79930607/19efc68c-c8f6-47a6-8582-fce9876fab62)

Quando é aplicado o filtro de exibir deletados:

![image](https://github.com/L-W-payments/asaas-payment/assets/79930607/b8a6714b-e89a-46f8-a6ef-2801ac56f68a)

