### PR TITLE
Adicionando filtro para exibir cobranças deletadas

### DIFF
--- a/grails-app/assets/javascripts/PaymentListController.js
+++ b/grails-app/assets/javascripts/PaymentListController.js
@@ -34,11 +34,9 @@ function PaymentListController(reference) {
             inputReference.readonly = true;
 
             var filterData = filterReference.getFilterData();
+            filterData.payerName = inputReference.value;
 
-            tableReference.params = {
-                payerName: inputReference.value,
-                filters: filterData.list
-            }
+            tableReference.params = filterData;
         });
 
         tableReference.addEventListener("atlas-table-after-search", function () {

--- a/grails-app/assets/javascripts/PaymentListController.js
+++ b/grails-app/assets/javascripts/PaymentListController.js
@@ -2,7 +2,7 @@ function PaymentListController(reference) {
 
     var tableReference = reference.querySelector(".js-payment-list-table");
     var inputReference = reference.querySelector(".js-payment-search-input");
-    var filterReference = reference.querySelector(".js-payment-filter-input")
+    var filterReference = reference.querySelector(".js-payment-filter-input");
     var deleteRow = null;
 
     function init() {

--- a/grails-app/assets/javascripts/PaymentListController.js
+++ b/grails-app/assets/javascripts/PaymentListController.js
@@ -2,12 +2,24 @@ function PaymentListController(reference) {
 
     var tableReference = reference.querySelector(".js-payment-list-table");
     var inputReference = reference.querySelector(".js-payment-search-input");
+    var filterReference = reference.querySelector(".js-payment-filter-input")
     var deleteRow = null;
 
     function init() {
         bindInputReference();
         bindTableSearch();
         bindTableActions();
+        bindFilterReference()
+    }
+
+    function bindFilterReference() {
+        filterReference.addEventListener("atlas-apply-filter", function () {
+            tableReference.fetchRecords(true);
+        });
+
+        filterReference.addEventListener("atlas-clean-filter", function () {
+            tableReference.fetchRecords(true);
+        });
     }
 
     function bindInputReference() {
@@ -18,9 +30,14 @@ function PaymentListController(reference) {
 
     function bindTableSearch() {
         tableReference.addEventListener("atlas-table-before-search", function () {
+            filterReference.enableButtons();
             inputReference.readonly = true;
+
+            var filterData = filterReference.getFilterData();
+
             tableReference.params = {
-                payerName: inputReference.value
+                payerName: inputReference.value,
+                filters: filterData.list
             }
         });
 

--- a/grails-app/assets/javascripts/PaymentListController.js
+++ b/grails-app/assets/javascripts/PaymentListController.js
@@ -9,7 +9,7 @@ function PaymentListController(reference) {
         bindInputReference();
         bindTableSearch();
         bindTableActions();
-        bindFilterReference()
+        bindFilterReference();
     }
 
     function bindFilterReference() {

--- a/grails-app/controllers/com/miniasaaslw/controller/payment/PaymentController.groovy
+++ b/grails-app/controllers/com/miniasaaslw/controller/payment/PaymentController.groovy
@@ -67,12 +67,8 @@ class PaymentController extends BaseController {
 
     def loadTableContent() {
         Map search = [:]
-        def filters = params.filters
 
-        if (filters) {
-            if (filters.contains("includeDeleted")) search.includeDeleted = true
-        }
-
+        if (params.includeDeleted) search.includeDeleted = Boolean.valueOf(params.includeDeleted)
         if (params.payerName) search."payerName[like]" = params.payerName
 
         List<Payment> paymentList = paymentService.list(search, getLimitPerPage(), getOffset())

--- a/grails-app/controllers/com/miniasaaslw/controller/payment/PaymentController.groovy
+++ b/grails-app/controllers/com/miniasaaslw/controller/payment/PaymentController.groovy
@@ -67,6 +67,12 @@ class PaymentController extends BaseController {
 
     def loadTableContent() {
         Map search = [:]
+        def filters = params.filters
+
+        if (filters) {
+            if (filters.contains("includeDeleted")) search.includeDeleted = true
+        }
+
         if (params.payerName) search."payerName[like]" = params.payerName
 
         List<Payment> paymentList = paymentService.list(search, getLimitPerPage(), getOffset())

--- a/grails-app/views/payment/list.gsp
+++ b/grails-app/views/payment/list.gsp
@@ -14,8 +14,8 @@
     </atlas-toolbar>
     <atlas-filter class="js-payment-filter-input">
       <atlas-filter-form slot="simple-filter">
-        <atlas-filter-group header="Listagem" name="list" slot="col-1">
-          <atlas-checkbox value="includeDeleted">Exibir deletados</atlas-checkbox>
+        <atlas-filter-group header="Listagem" name="includeDeleted" slot="col-1">
+          <atlas-checkbox value="true">Exibir deletados</atlas-checkbox>
         </atlas-filter-group>
       </atlas-filter-form>
     </atlas-filter>

--- a/grails-app/views/payment/list.gsp
+++ b/grails-app/views/payment/list.gsp
@@ -12,6 +12,13 @@
                           slot="search"></atlas-search-input>
       <atlas-button href="/payment" description="Adicionar" icon="plus" slot="actions"></atlas-button>
     </atlas-toolbar>
+    <atlas-filter class="js-payment-filter-input">
+      <atlas-filter-form slot="simple-filter">
+        <atlas-filter-group header="Listagem" name="list" slot="col-1">
+          <atlas-checkbox value="includeDeleted">Exibir deletados</atlas-checkbox>
+        </atlas-filter-group>
+      </atlas-filter-form>
+    </atlas-filter>
 
     <g:render template="/payment/templates/table"/>
     <asset:javascript src="PaymentListController.js"/>

--- a/grails-app/views/payment/templates/_tableContent.gsp
+++ b/grails-app/views/payment/templates/_tableContent.gsp
@@ -18,6 +18,16 @@
             <g:formatDate date="${payment.dueDate}" format="dd/MM/yyyy"/>
         </atlas-table-col>
         <atlas-button-group slot="actions" group-after="2">
+            <g:if test="${payment.deleted}">
+                <atlas-icon-button
+                        data-action=""
+                        tooltip="Restaurar cobrança"
+                        icon="refresh"
+                        theme="warning"
+                        description="Restaurar cobrança">
+                </atlas-icon-button>
+            </g:if>
+            <g:else>
             <atlas-icon-button
                     data-action="delete"
                     tooltip="Remover cobrança"
@@ -25,6 +35,7 @@
                     theme="danger"
                     description="Remover cobrança">
             </atlas-icon-button>
+            </g:else>
         </atlas-button-group>
     </atlas-table-row>
 </g:each>


### PR DESCRIPTION
### Impacto

Agora é possível visualizar cobranças que foram deletadas, para futuramente ser possível restaurá-las

Foi adicionado um botão de "restaurar" que por enquanto ainda não é funcional, é só um indicativo de que aquela cobrança em específico na listagem está deletada

### PR Predecessora

[90](https://github.com/L-W-payments/asaas-payment/pull/90)

### Link da tarefa

[124](https://github.com/orgs/L-W-payments/projects/1/views/1?pane=issue&itemId=65886600)

### Prints do desenvolvimento

Filtro desativado:
![image](https://github.com/L-W-payments/asaas-payment/assets/79930607/5e832b12-ef22-41d7-943e-ce5aee33417e)

Filtro ativado:
![image](https://github.com/L-W-payments/asaas-payment/assets/79930607/c2084cc9-6b9a-4509-a236-b8e3d826001e)
