### PR TITLE
Corrigindo tela de pagamento

### DIFF
--- a/grails-app/views/payment/checkout.gsp
+++ b/grails-app/views/payment/checkout.gsp
@@ -57,7 +57,7 @@
                     <atlas-divider spacing="16"></atlas-divider>
 
 
-                    <form action="${createLink(controller: 'payment', action: 'pay')}">
+                    <atlas-form action="${createLink(controller: 'payment', action: 'updateToReceived')}">
                         <g:if test="${payment.paymentStatus.isPending()}">
                             <atlas-input hidden name="id" value="${payment.id}"></atlas-input>
                             <atlas-button description="Pagar" theme="success" submit block></atlas-button>
@@ -69,7 +69,7 @@
                                     theme="${payment.paymentStatus.isReceived() ? 'highlight' : 'danger'}"
                                     block></atlas-button>
                         </g:else>
-                    </form>
+                    </atlas-form>
                 </atlas-panel>
             </atlas-grid>
         </atlas-page-content>


### PR DESCRIPTION
### Impacto

Antes o botão de pagar não estava funcionando, agora é possível pagar uma cobrança.

### PR Predecessora

### Link da tarefa

[Tarefa 150](https://github.com/L-W-payments/asaas-payment/issues/150)

### Prints do desenvolvimento