### PR TITLE
Usando a taglib de formatação de datas nos gsps

### DIFF
--- a/grails-app/taglib/com/miniasaaslw/DateTimeTagLib.groovy
+++ b/grails-app/taglib/com/miniasaaslw/DateTimeTagLib.groovy
@@ -5,7 +5,7 @@ import com.miniasaaslw.utils.DateUtils
 class DateTimeTagLib {
     static namespace = "dateTimeTagLib"
 
-    def datetime = { attrs ->
+    def dateTime = { attrs ->
         String format = DateUtils.DATE_FORMAT
         out << g.formatDate(format: format, date: attrs.date)
     }

--- a/grails-app/views/payer/templates/_tableContent.gsp
+++ b/grails-app/views/payer/templates/_tableContent.gsp
@@ -10,7 +10,7 @@
             ${payer.email}
         </atlas-table-col>
         <atlas-table-col>
-            <g:formatDate date="${payer.dateCreated}" format="dd/MM/yyyy"/>
+            ${dateTimeTagLib.datetime(date: payer.dateCreated)}
         </atlas-table-col>
         <atlas-button-group slot="actions" group-after="2">
             <atlas-icon-button

--- a/grails-app/views/payer/templates/_tableContent.gsp
+++ b/grails-app/views/payer/templates/_tableContent.gsp
@@ -10,7 +10,7 @@
             ${payer.email}
         </atlas-table-col>
         <atlas-table-col>
-            ${dateTimeTagLib.datetime(date: payer.dateCreated)}
+            ${dateTimeTagLib.dateTime(date: payer.dateCreated)}
         </atlas-table-col>
         <atlas-button-group slot="actions" group-after="2">
             <atlas-icon-button

--- a/grails-app/views/payment/checkout.gsp
+++ b/grails-app/views/payment/checkout.gsp
@@ -28,7 +28,7 @@
                     <atlas-layout justify="space-between" inline>
                         <atlas-summary-item
                                 label="Data de vencimento"
-                                description="${dateTimeTagLib.datetime(date: payment.dateCreated)}"></atlas-summary-item>
+                                description="${dateTimeTagLib.dateTime(date: payment.dateCreated)}"></atlas-summary-item>
 
                         <atlas-summary-item
                                 label="Situação"

--- a/grails-app/views/payment/checkout.gsp
+++ b/grails-app/views/payment/checkout.gsp
@@ -28,7 +28,7 @@
                     <atlas-layout justify="space-between" inline>
                         <atlas-summary-item
                                 label="Data de vencimento"
-                                description="${formatDate(date: payment.dueDate, format: 'dd/MM/yyyy')}"></atlas-summary-item>
+                                description="${dateTimeTagLib.datetime(date: payment.dateCreated)}"></atlas-summary-item>
 
                         <atlas-summary-item
                                 label="Situação"

--- a/grails-app/views/payment/show.gsp
+++ b/grails-app/views/payment/show.gsp
@@ -44,7 +44,7 @@
                 </atlas-col>
                 <atlas-col lg="4" md="4">
                   <atlas-datepicker name="dueDate" label="Vencimento da cobrança" prevent-past-date
-                                    required value="${dateTimeTagLib.datetime(date: payment.dueDate)}"></atlas-datepicker>
+                                    required value="${dateTimeTagLib.dateTime(date: payment.dueDate)}"></atlas-datepicker>
                 </atlas-col>
               </atlas-row>
             </atlas-grid>

--- a/grails-app/views/payment/show.gsp
+++ b/grails-app/views/payment/show.gsp
@@ -44,7 +44,7 @@
                 </atlas-col>
                 <atlas-col lg="4" md="4">
                   <atlas-datepicker name="dueDate" label="Vencimento da cobrança" prevent-past-date
-                                    required value="<g:formatDate date="${payment.dueDate}" format="dd/MM/yyyy"/>"></atlas-datepicker>
+                                    required value="${dateTimeTagLib.datetime(date: payment.dueDate)}"></atlas-datepicker>
                 </atlas-col>
               </atlas-row>
             </atlas-grid>

--- a/grails-app/views/payment/templates/_tableContent.gsp
+++ b/grails-app/views/payment/templates/_tableContent.gsp
@@ -15,7 +15,7 @@
             ${message(code: "paymentStatus.${payment.paymentStatus}.label")}
         </atlas-table-col>
         <atlas-table-col>
-            ${dateTimeTagLib.datetime(date: payment.dueDate)}
+            ${dateTimeTagLib.dateTime(date: payment.dueDate)}
         </atlas-table-col>
         <atlas-button-group slot="actions" group-after="2">
             <g:if test="${payment.deleted}">

--- a/grails-app/views/payment/templates/_tableContent.gsp
+++ b/grails-app/views/payment/templates/_tableContent.gsp
@@ -15,7 +15,7 @@
             ${message(code: "paymentStatus.${payment.paymentStatus}.label")}
         </atlas-table-col>
         <atlas-table-col>
-            <g:formatDate date="${payment.dueDate}" format="dd/MM/yyyy"/>
+            ${dateTimeTagLib.datetime(date: payment.dueDate)}
         </atlas-table-col>
         <atlas-button-group slot="actions" group-after="2">
             <g:if test="${payment.deleted}">


### PR DESCRIPTION
### Impacto
Agora está sendo usado a taglib de formatação de datas nos gsps

### PR Predecessora

### Link da tarefa
[108](https://github.com/orgs/L-W-payments/projects/1/views/1?pane=issue&itemId=65037209)

### Prints do desenvolvimento