### PR TITLE
Implementando restauração do pagador

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ delete para registros no banco de dados.
 - [x] Deve ser possível um cliente listar um pagador específico;
 - [x] Deve ser possível um cliente atualizar um pagador;
 - [x] Deve ser possível um cliente deletar um pagador;
-- [ ] Deve ser possível um cliente restaurar um pagador;
+- [x] Deve ser possível um cliente restaurar um pagador;
 - [x] Deve ser possível um cliente listar todas as notificações;
 - [x] Deve ser possível que o pagador pague uma cobrança;
 - [x] Deve ser possível um cliente confirmar o recebimento em dinheiro de uma cobrança;

--- a/grails-app/assets/javascripts/PayerListController.js
+++ b/grails-app/assets/javascripts/PayerListController.js
@@ -3,7 +3,7 @@ function PayerListController(reference) {
     var tableReference = reference.querySelector(".js-payer-list-table");
     var inputReference = reference.querySelector(".js-payer-search-input");
     var filterReference = reference.querySelector(".js-payer-filter-input");
-    var deleteRow = null;
+    var currentRow = null;
 
     function init() {
         bindInputReference();
@@ -49,21 +49,27 @@ function PayerListController(reference) {
         tableReference.addEventListener("atlas-table-action-click", function (event) {
             var button = event.detail.button;
             var buttonAction = button.dataset.action;
-            if (buttonAction == "edit") {
+
+            if (buttonAction === "edit") {
                 window.location = event.detail.row.href;
                 return;
             }
-            if (buttonAction == "delete") {
+
+            if (buttonAction === "delete") {
                 openConfirmDeleteModal();
-                deleteRow = event.detail.row;
+                currentRow = event.detail.row;
                 return;
             }
 
+            if (buttonAction === "restore") {
+                openConfirmRestoreModal();
+                currentRow = event.detail.row;
+            }
         });
     }
 
     function confirmDelete(modal) {
-        Atlas.request.post(deleteRow.dataset.deleteUrl).then(function (response) {
+        Atlas.request.post(currentRow.dataset.actionUrl).then(function (response) {
             if (response.success) {
                 Atlas.notifications.showAlert("Pagador removido com sucesso!", "success");
                 tableReference.fetchRecords(true);
@@ -87,6 +93,32 @@ function PayerListController(reference) {
         })
     }
 
+    function confirmRestore(modal) {
+        Atlas.request.post(currentRow.dataset.actionUrl).then(function (response) {
+
+            if (response.success) {
+                Atlas.notifications.showAlert("Pagador restaurado com sucesso!", "success");
+                tableReference.fetchRecords(true);
+                modal.closeModal();
+                return;
+            }
+
+            Atlas.notifications.showAlert(response.alert, "error");
+        });
+    }
+
+    function openConfirmRestoreModal() {
+        Atlas.notifications.showConfirmation({
+            illustration: "user-avatar-groups",
+            title: "Deseja restaurar este pagador?",
+            confirmButton: {
+                description: "Confirmar restauração",
+                theme: "primary"
+            },
+            onConfirm: confirmRestore,
+            disableAutoClose: false
+        })
+    }
 
     init();
 }

--- a/grails-app/controllers/com/miniasaaslw/controller/payer/PayerController.groovy
+++ b/grails-app/controllers/com/miniasaaslw/controller/payer/PayerController.groovy
@@ -5,7 +5,7 @@ import com.miniasaaslw.domain.customer.Customer
 import com.miniasaaslw.domain.payer.Payer
 import com.miniasaaslw.adapters.payer.PayerAdapter
 import com.miniasaaslw.repository.customer.CustomerRepository
-
+import com.miniasaaslw.utils.LoggedCustomer
 import grails.converters.JSON
 import grails.validation.ValidationException
 
@@ -59,7 +59,7 @@ class PayerController extends BaseController {
         try {
             Long id = params.long("id")
 
-            payerService.restore(id)
+            payerService.restore(LoggedCustomer.CUSTOMER.id, id)
             render([success: true] as JSON)
         } catch (RuntimeException runtimeException) {
             flash.messageInfo = [messages: [runtimeException.getMessage()], messageType: "error"]

--- a/grails-app/controllers/com/miniasaaslw/controller/payer/PayerController.groovy
+++ b/grails-app/controllers/com/miniasaaslw/controller/payer/PayerController.groovy
@@ -63,10 +63,10 @@ class PayerController extends BaseController {
             render([success: true] as JSON)
         } catch (RuntimeException runtimeException) {
             flash.messageInfo = [messages: [runtimeException.getMessage()], messageType: "error"]
-            render([success: false] as JSON)
+            render([success: false, alert: runtimeException.getMessage()] as JSON)
         } catch (Exception exception) {
             flash.messageInfo = [messages: [message(code: "payer.errors.restore.unknown")], messageType: "error"]
-            render([success: false] as JSON)
+            render([success: false, alert: message(code: "payer.errors.restore.unknown")] as JSON)
         }
     }
 

--- a/grails-app/services/com/miniasaaslw/service/payer/PayerService.groovy
+++ b/grails-app/services/com/miniasaaslw/service/payer/PayerService.groovy
@@ -31,8 +31,8 @@ class PayerService {
         return payer
     }
 
-    public void restore(Long id) {
-        Payer payer = PayerRepository.query([id: id, includeDeleted: true]).get()
+    public void restore(Long customerId, Long id) {
+        Payer payer = PayerRepository.query([customerId: customerId, id: id, includeDeleted: true]).get()
 
         if (!payer) throw new RuntimeException(MessageUtils.getMessage("payer.errors.notFound"))
 

--- a/grails-app/views/payer/templates/_tableContent.gsp
+++ b/grails-app/views/payer/templates/_tableContent.gsp
@@ -1,8 +1,7 @@
 <g:each var="payer" in="${payerList}">
     <atlas-table-row
             href="${createLink(controller: "payer", action: "show", id: payer.id)}"
-            data-delete-url="${createLink(controller: "payer", action: "fetchDelete", id: payer.id)}"
-    >
+            data-action-url="${createLink(controller: "payer", action: "${payer.deleted ? 'restore' : 'fetchDelete'}", id: payer.id)}">
         <atlas-table-col>
             ${payer.name}
         </atlas-table-col>
@@ -22,7 +21,7 @@
             </atlas-icon-button>
             <g:if test="${payer.deleted}">
                 <atlas-icon-button
-                        data-action=""
+                        data-action="restore"
                         tooltip="Restaurar pagador"
                         icon="refresh"
                         theme="warning"


### PR DESCRIPTION
### Impacto

Agora o botão de restaurar um pagador na listagem está funcionando, permitindo que pagadores deletados previamente possam ser restaurados.

Também foi alterado o uso do service, sendo obrigatório ser passado o cliente do pagador, para evitar restaurar pagadores de outros clientes.

### PR Predecessora

### Link da tarefa

[Tarefa 159](https://github.com/L-W-payments/asaas-payment/issues/159)

### Prints do desenvolvimento

![image](https://github.com/L-W-payments/asaas-payment/assets/29075798/d89dca66-4e7a-4f27-85cb-c5b9ef66f8f8)
![image](https://github.com/L-W-payments/asaas-payment/assets/29075798/2addf0a2-c7e1-494f-9253-163c71923efa)
