### PR TITLE
Implementando restauração da cobrança

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ delete para registros no banco de dados.
 - [x] Deve ser possível um cliente listar todas as cobranças;
 - [x] Deve ser possível um cliente listar uma cobrança específica;
 - [x] Deve ser possível um cliente deletar uma cobrança;
-- [ ] Deve ser possível um cliente restaurar uma cobrança;
+- [x] Deve ser possível um cliente restaurar uma cobrança;
 - [x] Deve ser possível um cliente selecionar um pagador para uma cobrança;
 - [x] Deve ser possível um cliente criar um pagador;
 - [x] Deve ser possível um cliente listar todos os pagadores;

--- a/grails-app/controllers/com/miniasaaslw/controller/payment/PaymentController.groovy
+++ b/grails-app/controllers/com/miniasaaslw/controller/payment/PaymentController.groovy
@@ -30,14 +30,14 @@ class PaymentController extends BaseController {
         try {
             Long id = params.long("id")
 
-            paymentService.restore(id)
+            paymentService.restore(LoggedCustomer.CUSTOMER.id, id)
             render([success: true] as JSON)
         } catch (RuntimeException runtimeException) {
             flash.messageInfo = [messages: [runtimeException.getMessage()], messageType: "error"]
-            render([success: false] as JSON)
+            render([success: false, alert: runtimeException.getMessage()] as JSON)
         } catch (Exception exception) {
             flash.messageInfo = [messages: [message(code: "payment.errors.restore.unknown")], messageType: "error"]
-            render([success: false] as JSON)
+            render([success: false, alert: message(code: "payment.errors.restore.unknown")] as JSON)
         }
     }
 

--- a/grails-app/services/com/miniasaaslw/service/payment/PaymentService.groovy
+++ b/grails-app/services/com/miniasaaslw/service/payment/PaymentService.groovy
@@ -45,8 +45,8 @@ class PaymentService {
         return payment
     }
 
-    public void restore(Long id) {
-        Payment payment = PaymentRepository.query([id: id, includeDeleted: true]).get()
+    public void restore(Long customerId, Long id) {
+        Payment payment = PaymentRepository.query([customerId: customerId, id: id, includeDeleted: true]).get()
 
         if (!payment) throw new RuntimeException(MessageUtils.getMessage("payment.errors.notFound"))
 

--- a/grails-app/views/payment/list.gsp
+++ b/grails-app/views/payment/list.gsp
@@ -10,15 +10,17 @@
     <atlas-toolbar>
       <atlas-search-input class="js-payment-search-input" placeholder="Pesquisar" icon="magnifier"
                           slot="search"></atlas-search-input>
+
+        <atlas-filter class="js-payment-filter-input" slot="filter">
+            <atlas-filter-form slot="simple-filter">
+                <atlas-filter-group header="Listagem" name="includeDeleted" slot="col-1">
+                    <atlas-checkbox value="true">Exibir deletados</atlas-checkbox>
+                </atlas-filter-group>
+            </atlas-filter-form>
+        </atlas-filter>
+
       <atlas-button href="/payment" description="Adicionar" icon="plus" slot="actions"></atlas-button>
     </atlas-toolbar>
-    <atlas-filter class="js-payment-filter-input">
-      <atlas-filter-form slot="simple-filter">
-        <atlas-filter-group header="Listagem" name="includeDeleted" slot="col-1">
-          <atlas-checkbox value="true">Exibir deletados</atlas-checkbox>
-        </atlas-filter-group>
-      </atlas-filter-form>
-    </atlas-filter>
 
     <g:render template="/payment/templates/table"/>
     <asset:javascript src="PaymentListController.js"/>

--- a/grails-app/views/payment/templates/_tableContent.gsp
+++ b/grails-app/views/payment/templates/_tableContent.gsp
@@ -1,6 +1,6 @@
 <g:each var="payment" in="${paymentList}">
     <atlas-table-row
-            data-delete-url="${createLink(controller: 'payment', action: 'fetchDelete', id: payment.id)}"
+            data-action-url="${createLink(controller: 'payment', action: "${payment.deleted ? 'restore' : 'fetchDelete'}", id: payment.id)}"
     >
         <atlas-table-col>
             ${payment.payer.name}
@@ -20,7 +20,7 @@
         <atlas-button-group slot="actions" group-after="2">
             <g:if test="${payment.deleted}">
                 <atlas-icon-button
-                        data-action=""
+                        data-action="restore"
                         tooltip="Restaurar cobrança"
                         icon="refresh"
                         theme="warning"


### PR DESCRIPTION
### Impacto

Agora o botão de restaurar um pagador na listagem está funcionando, permitindo que pagadores deletados previamente possam ser restaurados.

Também foi alterado o uso do service, sendo obrigatório ser passado o cliente da cobrança, para evitar restaurar cobranças de outros clientes.

### PR Predecessora

### Link da tarefa

[Tarefa 160](https://github.com/L-W-payments/asaas-payment/issues/160)

### Prints do desenvolvimento

![image](https://github.com/L-W-payments/asaas-payment/assets/29075798/4df15027-ac94-4059-92af-89a1668911d5)
![image](https://github.com/L-W-payments/asaas-payment/assets/29075798/bc145973-c66c-4299-ac2c-0f3f959513a9)
