### PR TITLE
Alterando nome da pagina de visualização de pagador

### DIFF
--- a/grails-app/views/payer/show.gsp
+++ b/grails-app/views/payer/show.gsp
@@ -2,22 +2,24 @@
 <html lang="pt-br">
 
 <head>
-    <meta name="layout" content="main" />
-    <title>Pagadores - Asaas</title>
+    <meta name="layout" content="main"/>
+    <title>Pagador - Asaas</title>
 </head>
 
-<body page-title="Cadastro do pagador" >
-<atlas-form-panel header="Dados de ${payer.name}" class="js-person-form" action="${createLink(controller: 'payer', action: 'update', id: payer.id)}">
+<body page-title="Visualizar pagador">
+    <atlas-form-panel header="Dados de ${payer.name}" class="js-person-form"
+                      action="${createLink(controller: 'payer', action: 'update', id: payer.id)}">
 
-    <atlas-button slot="actions" data-panel-start-editing icon="pencil" description="Editar"></atlas-button>
-    <atlas-button type="outlined" slot="actions" href="${createLink(controller: 'payer', action: 'delete', id: payer.id)}"
-                  description="Apagar"></atlas-button>
-    <atlas-input hidden name="customerId" value="${payer.customerId}"></atlas-input>
-    <atlas-input hidden name="country" value="Brasil"></atlas-input>
-        <g:render template="/templates/basePersonForm"
-                  model="${[person: payer]}"></g:render>
+        <atlas-button slot="actions" data-panel-start-editing icon="pencil" description="Editar"></atlas-button>
+        <atlas-button type="outlined" slot="actions"
+                      href="${createLink(controller: 'payer', action: 'delete', id: payer.id)}"
+                      description="Apagar"></atlas-button>
 
-</atlas-form-panel>
+        <atlas-input hidden name="customerId" value="${payer.customerId}"></atlas-input>
+        <atlas-input hidden name="country" value="Brasil"></atlas-input>
+
+        <g:render template="/templates/basePersonForm" model="${[person: payer]}"/>
+    </atlas-form-panel>
 </body>
 
 </html>


### PR DESCRIPTION
### Impacto

Agora o título da página aparece corretamente como **Visualizar pagador**,  sendo chamado antes de **Cadastro de pagador**

### PR Predecessora

### Link da tarefa

[Tarefa 176](https://github.com/L-W-payments/asaas-payment/issues/176)

### Prints do desenvolvimento

![image](https://github.com/L-W-payments/asaas-payment/assets/29075798/ddc4f9e6-131a-4793-9dcd-43ce77013202)
