### PR TITLE
[Taglib de formatação] - Adiciona formaters para CPF, CNPJ, Telefone e Data longa

### DIFF
--- a/grails-app/taglib/com/miniasaaslw/FormatterTagLib.groovy
+++ b/grails-app/taglib/com/miniasaaslw/FormatterTagLib.groovy
@@ -2,8 +2,8 @@ package com.miniasaaslw
 
 import com.miniasaaslw.utils.DateUtils
 
-class DateTimeTagLib {
-    static namespace = "dateTimeTagLib"
+class FormatterTagLib {
+    static namespace = "formatterTagLib"
 
     def dateTime = { attrs ->
         String format = DateUtils.SIMPLE_DATE_FORMAT

--- a/grails-app/taglib/com/miniasaaslw/FormatterTagLib.groovy
+++ b/grails-app/taglib/com/miniasaaslw/FormatterTagLib.groovy
@@ -9,4 +9,10 @@ class FormatterTagLib {
         String format = DateUtils.SIMPLE_DATE_FORMAT
         out << g.formatDate(format: format, date: attrs.date)
     }
+
+    def cpf = { attrs ->
+        String cpf = attrs.cpf
+        out << cpf[0..2] + "." + cpf[3..5] + "." + cpf[6..8] + "-" + cpf[9..10]
+    }
+
 }

--- a/grails-app/taglib/com/miniasaaslw/FormatterTagLib.groovy
+++ b/grails-app/taglib/com/miniasaaslw/FormatterTagLib.groovy
@@ -6,7 +6,9 @@ class FormatterTagLib {
     static namespace = "formatterTagLib"
 
     def dateTime = { attrs ->
-        String format = DateUtils.SIMPLE_DATE_FORMAT
+        Boolean longDate = attrs.longDate ?: false
+        String format = longDate ? DateUtils.LONG_DATE_FORMAT : DateUtils.SIMPLE_DATE_FORMAT
+
         out << g.formatDate(format: format, date: attrs.date)
     }
 

--- a/grails-app/taglib/com/miniasaaslw/FormatterTagLib.groovy
+++ b/grails-app/taglib/com/miniasaaslw/FormatterTagLib.groovy
@@ -20,4 +20,9 @@ class FormatterTagLib {
         out << cnpj[0..1] + "." + cnpj[2..4] + "." + cnpj[5..7] + "/" + cnpj[8..11] + "-" + cnpj[12..13]
     }
 
+    def phone = { attrs ->
+        String phone = attrs.phone
+        out << "(" + phone[0..1] + ") " + phone[2..6] + "-" + phone[7..10]
+    }
+
 }

--- a/grails-app/taglib/com/miniasaaslw/FormatterTagLib.groovy
+++ b/grails-app/taglib/com/miniasaaslw/FormatterTagLib.groovy
@@ -15,4 +15,9 @@ class FormatterTagLib {
         out << cpf[0..2] + "." + cpf[3..5] + "." + cpf[6..8] + "-" + cpf[9..10]
     }
 
+    def cnpj = { attrs ->
+        String cnpj = attrs.cnpj
+        out << cnpj[0..1] + "." + cnpj[2..4] + "." + cnpj[5..7] + "/" + cnpj[8..11] + "-" + cnpj[12..13]
+    }
+
 }

--- a/grails-app/views/payer/templates/_tableContent.gsp
+++ b/grails-app/views/payer/templates/_tableContent.gsp
@@ -9,7 +9,7 @@
             ${payer.email}
         </atlas-table-col>
         <atlas-table-col>
-            ${dateTimeTagLib.dateTime(date: payer.dateCreated)}
+            ${formatterTagLib.dateTime(date: payer.dateCreated)}
         </atlas-table-col>
         <atlas-button-group slot="actions" group-after="2">
             <atlas-icon-button

--- a/grails-app/views/payment/checkout.gsp
+++ b/grails-app/views/payment/checkout.gsp
@@ -28,7 +28,7 @@
                     <atlas-layout justify="space-between" inline>
                         <atlas-summary-item
                                 label="Data de vencimento"
-                                description="${dateTimeTagLib.dateTime(date: payment.dateCreated)}"></atlas-summary-item>
+                                description="${formatterTagLib.dateTime(date: payment.dateCreated)}"></atlas-summary-item>
 
                         <atlas-summary-item
                                 label="Situação"

--- a/grails-app/views/payment/show.gsp
+++ b/grails-app/views/payment/show.gsp
@@ -57,7 +57,7 @@
                 </atlas-col>
                 <atlas-col lg="4" md="4">
                   <atlas-datepicker name="dueDate" label="Vencimento da cobrança" prevent-past-date
-                                    required value="${dateTimeTagLib.dateTime(date: payment.dueDate)}"></atlas-datepicker>
+                                    required value="${formatterTagLib.dateTime(date: payment.dueDate)}"></atlas-datepicker>
                 </atlas-col>
               </atlas-row>
             </atlas-grid>

--- a/grails-app/views/payment/templates/_tableContent.gsp
+++ b/grails-app/views/payment/templates/_tableContent.gsp
@@ -16,7 +16,7 @@
             ${message(code: "paymentStatus.${payment.paymentStatus}.label")}
         </atlas-table-col>
         <atlas-table-col>
-            ${dateTimeTagLib.dateTime(date: payment.dueDate)}
+            ${formatterTagLib.dateTime(date: payment.dueDate)}
         </atlas-table-col>
         <atlas-button-group slot="actions" group-after="2">
             <g:if test="${payment.deleted}">

--- a/grails-app/views/paymentReceipt/templates/_receipt.gsp
+++ b/grails-app/views/paymentReceipt/templates/_receipt.gsp
@@ -42,7 +42,7 @@
 
         <atlas-text bold muted size="sm">
             Data de pagamento: <atlas-text muted
-                                           size="sm">${g.formatDate(date: receipt.dateCreated, format: "dd/MM/yyyy 'às' HH:mm")}</atlas-text>
+                                           size="sm">${formatterTagLib.dateTime(date: receipt.dateCreated, longDate: true)}</atlas-text>
         </atlas-text>
 
         <atlas-text bold muted size="sm">

--- a/grails-app/views/paymentReceipt/templates/_receipt.gsp
+++ b/grails-app/views/paymentReceipt/templates/_receipt.gsp
@@ -35,7 +35,7 @@
 
         <atlas-text bold muted size="sm">
             Data do vencimento: <atlas-text muted
-                                            size="sm">${dateTimeTagLib.dateTime(date: receipt.payment.dueDate)}</atlas-text>
+                                            size="sm">${formatterTagLib.dateTime(date: receipt.payment.dueDate)}</atlas-text>
         </atlas-text>
 
         <atlas-text bold muted size="sm">

--- a/grails-app/views/paymentReceipt/templates/_receipt.gsp
+++ b/grails-app/views/paymentReceipt/templates/_receipt.gsp
@@ -15,7 +15,7 @@
         <atlas-layout gap="2">
             <atlas-text muted size="sm">${receipt.payment.payer.name}</atlas-text>
             <atlas-text muted size="sm">${receipt.payment.payer.email}</atlas-text>
-            <atlas-text muted size="sm">${receipt.payment.payer.phone}</atlas-text>
+            <atlas-text muted size="sm">${formatterTagLib.phone(phone: receipt.payment.payer.phone)}</atlas-text>
         </atlas-layout>
 
         <atlas-image src="https://atlas.asaas.com/assets/images/logos/asaas-small-logo.svg"

--- a/grails-app/views/paymentReceipt/templates/_receipt.gsp
+++ b/grails-app/views/paymentReceipt/templates/_receipt.gsp
@@ -1,3 +1,5 @@
+<%@ page import="com.miniasaaslw.entity.enums.PersonType" %>
+
 <atlas-panel class="js-receipt-content">
     <atlas-layout inline justify="space-between">
         <atlas-heading size="h5">
@@ -55,10 +57,16 @@
             Nome do recebedor: <atlas-text muted
                                            size="sm">${receipt.payment.customer.name}</atlas-text>
         </atlas-text>
-
-        <atlas-text bold muted size="sm">
-            CPF/CNPJ: <atlas-text muted size="sm">${receipt.payment.customer.cpfCnpj}</atlas-text>
-        </atlas-text>
+        <g:if test="${receipt.payment.customer.personType.isNatural()}">
+            <atlas-text bold muted size="sm">
+                CPF: <atlas-text muted size="sm">${formatterTagLib.cpf(cpf: receipt.payment.customer.cpfCnpj)}</atlas-text>
+            </atlas-text>
+        </g:if>
+        <g:else>
+            <atlas-text bold muted size="sm">
+                CNPJ: <atlas-text muted size="sm">${formatterTagLib.cnpj(cnpj: receipt.payment.customer.cpfCnpj)}</atlas-text>
+            </atlas-text>
+        </g:else>
 
         <atlas-text bold muted size="sm">
             Instituição: <atlas-text muted

--- a/src/main/groovy/com/miniasaaslw/entity/enums/PersonType.groovy
+++ b/src/main/groovy/com/miniasaaslw/entity/enums/PersonType.groovy
@@ -1,10 +1,19 @@
 package com.miniasaaslw.entity.enums
 
 enum PersonType {
+
     NATURAL,
     LEGAL
 
     public static List<PersonType> getPersonTypeList() {
         return [PersonType.NATURAL, PersonType.LEGAL]
+    }
+
+    public Boolean isNatural() {
+        return this == NATURAL
+    }
+
+    public Boolean isLegal() {
+        return this == LEGAL
     }
 }

--- a/src/main/groovy/com/miniasaaslw/utils/DateUtils.groovy
+++ b/src/main/groovy/com/miniasaaslw/utils/DateUtils.groovy
@@ -4,7 +4,7 @@ import java.text.SimpleDateFormat
 
 class DateUtils {
 
-    public static final String LONG_DATE_FORMAT = "dd 'de' MMM 'de' yyyy"
+    public static final String LONG_DATE_FORMAT = "dd 'de' MMMM 'de' yyyy"
     public static final String SIMPLE_DATE_FORMAT = "dd/MM/yyyy"
 
     public static Date parseDate(String date) {


### PR DESCRIPTION
### Impacto
A DateTimeTagLib é refatorada para FormatterTagLib e é adicionado os métodos para formatar CPF, Cnpj e telefone.
 Também foi adicionado um atributo a mais do formatter da data, para formatar para a data longa. 

### PR Predecessora

### Link da tarefa
[198](https://github.com/orgs/L-W-payments/projects/1/views/1?pane=issue&itemId=66618148)

### Prints do desenvolvimento
