### PR TITLE
[User] Trata erro de tentar cadastrar um usuário com um email já existente

### DIFF
--- a/grails-app/i18n/messages_pt_BR.properties
+++ b/grails-app/i18n/messages_pt_BR.properties
@@ -63,7 +63,7 @@ typeMismatch.java.math.BigInteger=O campo {0} deve ser um número válido.
 general.errors.validation=Erro ao validar parâmetros.
 
 general.errors.cpfCnpj.duplicated=O CPF/CNPJ já existe.
-general.errors.email.duplicated=O e-mail já existe.
+general.errors.email.duplicated=O e-mail já está cadastrado.
 
 general.errors.name.required=O nome é obrigatório.
 general.errors.email.required=O e-mail é obrigatório.

--- a/grails-app/services/com/miniasaaslw/service/user/UserService.groovy
+++ b/grails-app/services/com/miniasaaslw/service/user/UserService.groovy
@@ -77,6 +77,10 @@ class UserService {
             user.errors.rejectValue("password", null, MessageUtils.getMessage("general.errors.password.weak"))
         }
 
+        if(UserRepository.query(["email": userAdapter.email]).exists()){
+            user.errors.rejectValue("email", null, MessageUtils.getMessage("general.errors.email.duplicated"))
+        }
+
         return user
     }
 

--- a/src/main/groovy/com/miniasaaslw/repository/user/UserRepository.groovy
+++ b/src/main/groovy/com/miniasaaslw/repository/user/UserRepository.groovy
@@ -20,6 +20,10 @@ class UserRepository implements Repository<User, UserRepository> {
                 eq("customer.id", search.customerId)
             }
 
+            if (search.containsKey("email")) {
+                eq("email", search.email)
+            }
+
             if (search.containsKey("email[like]")) {
                 ilike("email", "%" + search."email[like]" + "%")
             }
@@ -30,6 +34,7 @@ class UserRepository implements Repository<User, UserRepository> {
     List<String> listAllowedFilters() {
         return [
                 "customerId",
+                "email",
                 "email[like]"
         ]
     }


### PR DESCRIPTION
### Impacto
O erro ao tentar cadastrar um usuário com um email que já existe, agora é tratado
Antes estava a mensagem padrão do spring, agora é usado nossa mensagem personalizada

### PR Predecessora

### Link da tarefa
[220](https://github.com/orgs/L-W-payments/projects/1/views/1?pane=issue&itemId=67034516
)
### Prints do desenvolvimento

![image](https://github.com/L-W-payments/asaas-payment/assets/79930607/aef2c20e-c51b-49a0-a846-a62d668acab0)
