### PR TITLE
[Customer] Padronizar a checagem de existsBy email e CpfCnpj

### DIFF
--- a/grails-app/services/com/miniasaaslw/service/customer/CustomerService.groovy
+++ b/grails-app/services/com/miniasaaslw/service/customer/CustomerService.groovy
@@ -144,11 +144,11 @@ class CustomerService {
         }
 
         if (!isUpdate) {
-            if (CustomerRepository.exists([cpfCnpj: customerAdapter.cpfCnpj])) {
+            if (CustomerRepository.query([cpfCnpj: customerAdapter.cpfCnpj]).exists()) {
                 customer.errors.reject("cpfCnpj", null, MessageUtils.getMessage("general.errors.cpfCnpj.duplicated"))
             }
 
-            if (CustomerRepository.exists([email: customerAdapter.email])) {
+            if (CustomerRepository.query([email: customerAdapter.email]).exists()) {
                 customer.errors.reject("email", null, MessageUtils.getMessage("general.errors.email.duplicated"))
             }
         }

--- a/src/main/groovy/com/miniasaaslw/repository/customer/CustomerRepository.groovy
+++ b/src/main/groovy/com/miniasaaslw/repository/customer/CustomerRepository.groovy
@@ -36,7 +36,4 @@ class CustomerRepository implements Repository<Customer, CustomerRepository> {
         ]
     }
 
-    public static Boolean exists(Map search) {
-        return query(search).get().asBoolean()
-    }
 }


### PR DESCRIPTION
### Impacto
Agora é utilizado o `CustomerRepository.query([search]).exists()` para consultar na base se algo já existe, removendo o método estático criado antes de ser implementado o repositório base do asaas

### PR Predecessora

### Link da tarefa
[237](https://github.com/orgs/L-W-payments/projects/1/views/1?pane=issue&itemId=67199312)

### Prints do desenvolvimento