### PR TITLE
[Bugfix] Refatoração da validação de data de vencimento da cobrança

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     implementation "org.grails.plugins:quartz:2.0.13"
     implementation "org.grails.plugins:mail:4.0.0"
     implementation "org.grails.plugins:spring-security-core:5.0.0-RC1"
+    implementation "org.codehaus.groovy:groovy-dateutil:3.0.16"
     implementation ("org.quartz-scheduler:quartz:2.3.2") {
         exclude group: "slf4j-api", module: "c3p0"
     }

--- a/grails-app/services/com/miniasaaslw/service/payment/PaymentService.groovy
+++ b/grails-app/services/com/miniasaaslw/service/payment/PaymentService.groovy
@@ -264,7 +264,7 @@ class PaymentService {
     }
 
     private Boolean validateDueDate(Date dueDate) {
-        if (dueDate.before(DateUtils.today())) return false
+        if (dueDate.before(new Date().clearTime())) return false
 
         Date dateLimit = new Date()
 

--- a/grails-app/services/com/miniasaaslw/service/payment/PaymentService.groovy
+++ b/grails-app/services/com/miniasaaslw/service/payment/PaymentService.groovy
@@ -6,6 +6,7 @@ import com.miniasaaslw.adapters.payment.PaymentAdapter
 import com.miniasaaslw.domain.payment.Payment
 import com.miniasaaslw.entity.enums.payment.PaymentStatus
 import com.miniasaaslw.repository.payment.PaymentRepository
+import com.miniasaaslw.utils.DateUtils
 import com.miniasaaslw.utils.LoggedCustomer
 import com.miniasaaslw.utils.MessageUtils
 
@@ -263,7 +264,7 @@ class PaymentService {
     }
 
     private Boolean validateDueDate(Date dueDate) {
-        if (dueDate.before(new Date())) return false
+        if (dueDate.before(DateUtils.today())) return false
 
         Date dateLimit = new Date()
 

--- a/src/main/groovy/com/miniasaaslw/utils/DateUtils.groovy
+++ b/src/main/groovy/com/miniasaaslw/utils/DateUtils.groovy
@@ -27,4 +27,12 @@ class DateUtils {
         return calendar.getTime()
     }
 
+    public static Date today() {
+        Calendar calendar = Calendar.getInstance()
+        calendar.set(Calendar.HOUR_OF_DAY, 0)
+        calendar.set(Calendar.MINUTE, 0)
+        calendar.set(Calendar.SECOND, 0)
+        calendar.set(Calendar.MILLISECOND, 0)
+        return calendar.getTime()
+    }
 }

--- a/src/main/groovy/com/miniasaaslw/utils/DateUtils.groovy
+++ b/src/main/groovy/com/miniasaaslw/utils/DateUtils.groovy
@@ -26,13 +26,4 @@ class DateUtils {
         calendar.set(Calendar.DAY_OF_MONTH, calendar.getActualMaximum(Calendar.DAY_OF_MONTH))
         return calendar.getTime()
     }
-
-    public static Date today() {
-        Calendar calendar = Calendar.getInstance()
-        calendar.set(Calendar.HOUR_OF_DAY, 0)
-        calendar.set(Calendar.MINUTE, 0)
-        calendar.set(Calendar.SECOND, 0)
-        calendar.set(Calendar.MILLISECOND, 0)
-        return calendar.getTime()
-    }
 }


### PR DESCRIPTION
### Impacto
É corrigido o erro de validação da data de vencimento
- Não era possível criar uma cobrança que se vence no dia atual
- Acontecia porque a gente tava comparando com uma instância `new Date()`, que pega o dia atual, mas também a hora
- Então na hora de comparar utilizando o `before`, retornava false

### Solução
- Foi criado um método no DateUtils que retorna a data atual as 00:00

### PR Predecessora

### Link da tarefa
[254](https://github.com/orgs/L-W-payments/projects/1/views/1?pane=issue&itemId=67363975)

### Prints do desenvolvimento