### PR TITLE
[Bugfix] Corrigindo exceção lançada errada

### DIFF
--- a/grails-app/services/com/miniasaaslw/service/user/UserService.groovy
+++ b/grails-app/services/com/miniasaaslw/service/user/UserService.groovy
@@ -9,6 +9,7 @@ import com.miniasaaslw.utils.EmailUtils
 import com.miniasaaslw.utils.MessageUtils
 import com.miniasaaslw.utils.PasswordUtils
 import grails.compiler.GrailsCompileStatic
+
 import grails.gorm.transactions.Transactional
 import grails.validation.ValidationException
 
@@ -46,7 +47,7 @@ class UserService {
     public void delete(User loggedUser, Long id) {
         User user = find(loggedUser.customer.id, id)
 
-        if (loggedUser.id == user.id) throw new GenericException(MessageUtils.getMessage("user.errors.delete.self"))
+        if (loggedUser.id == user.id) throw new BusinessException(MessageUtils.getMessage("user.errors.delete.self"))
 
         if (!user.enabled) throw new BusinessException(MessageUtils.getMessage("user.errors.notFound"))
 


### PR DESCRIPTION
### Impacto
Corrigindo Exception lançada errada, esse conflito ocorreu por causa da refatoração do nome `GenericException` para `BusinessException`

### PR Predecessora

### Link da tarefa
[274](https://github.com/orgs/L-W-payments/projects/1/views/1?pane=issue&itemId=67499781)

### Prints do desenvolvimento