### PR TITLE
[Bugfix] Conserta redirect depois de cadastrar um novo customer

### DIFF
--- a/grails-app/controllers/com/miniasaaslw/controller/customer/CustomerController.groovy
+++ b/grails-app/controllers/com/miniasaaslw/controller/customer/CustomerController.groovy
@@ -31,7 +31,7 @@ class CustomerController extends BaseController {
     def save() {
         try {
             customerService.save(new CustomerAdapter(params), params)
-            redirect(uri: "/index", params: [registered: true])
+            redirect(uri: "/login/auth", params: [registered: true])
         } catch (Exception exception) {
             if (!handleException(exception)) addMessageCode("customer.errors.save.unknown", MessageType.ERROR)
 


### PR DESCRIPTION
### Impacto
Agora é redirecionado corretamente para a tela de login, com o params informando que o usuário acabou de ser criado

### PR Predecessora

### Link da tarefa
[278](https://github.com/orgs/L-W-payments/projects/1/views/1?pane=issue&itemId=67507367)

### Prints do desenvolvimento